### PR TITLE
Add viewable check for page itself

### DIFF
--- a/src/StructuredData/BreadcrumbStructuredData.php
+++ b/src/StructuredData/BreadcrumbStructuredData.php
@@ -64,7 +64,9 @@ class BreadcrumbStructuredData extends StructuredData
             $this->listItems->append($this->buildListItem($parent));
         }
 
-        $this->listItems->append($this->buildListItem($this->page));
+        if ($this->page->viewable()) {
+            $this->listItems->append($this->buildListItem($this->page));
+        }
     }
 
     private function buildListItem(Page $page)

--- a/src/StructuredData/BreadcrumbStructuredData.php
+++ b/src/StructuredData/BreadcrumbStructuredData.php
@@ -2,6 +2,7 @@
 
 namespace SeoMaestro\StructuredData;
 
+use ProcessWire\FieldsetPage;
 use ProcessWire\Page;
 use ProcessWire\TemplateFile;
 use ProcessWire\WireArray;
@@ -57,14 +58,14 @@ class BreadcrumbStructuredData extends StructuredData
 
     private function buildListItems()
     {
-        foreach ($this->page->parents('template!=home') as $parent) {
-            if (!$parent->viewable()) {
+        foreach ($this->page->parents('template!=root') as $parent) {
+            if (!$parent->viewable() || $this->page instanceof FieldsetPage) {
                 continue;
             }
             $this->listItems->append($this->buildListItem($parent));
         }
 
-        if ($this->page->viewable()) {
+        if ($this->page->viewable() && !$this->page instanceof FieldsetPage) {
             $this->listItems->append($this->buildListItem($this->page));
         }
     }


### PR DESCRIPTION
When SeoMaster field is set to a page fieldset (e.g. $page->meta->seo), the page fieldset should not be listed i nthe breadcrumbs aka structured data. So the page itself should be tested as viewable.