### PR TITLE
Don't allow autojoin FieldtypeSeoMaestro

### DIFF
--- a/FieldtypeSeoMaestro.module.php
+++ b/FieldtypeSeoMaestro.module.php
@@ -309,18 +309,17 @@ class FieldtypeSeoMaestro extends Fieldtype implements Module
 
         return $wrapper;
     }
-	
+
     /**
-     * 
      * {@inheritdoc}
      */
     public function ___getConfigAdvancedInputfields(Field $field)
     {
         $wrapper = parent::___getConfigAdvancedInputfields($field);
-	$wrapper->remove($wrapper->get('autojoin'));
-	return $wrapper;
+        $wrapper->remove($wrapper->get('autojoin'));
+        return $wrapper;
     }
-    
+
     /**
      * {@inheritdoc}
      */

--- a/FieldtypeSeoMaestro.module.php
+++ b/FieldtypeSeoMaestro.module.php
@@ -309,6 +309,15 @@ class FieldtypeSeoMaestro extends Fieldtype implements Module
 
         return $wrapper;
     }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function ___getConfigAdvancedInputfields(Field $field) {
+		$wrapper = parent::___getConfigAdvancedInputfields($field);
+        $wrapper->remove($wrapper->get('autojoin'));
+		return $wrapper;
+	}
 
     /**
      * {@inheritdoc}

--- a/FieldtypeSeoMaestro.module.php
+++ b/FieldtypeSeoMaestro.module.php
@@ -309,16 +309,18 @@ class FieldtypeSeoMaestro extends Fieldtype implements Module
 
         return $wrapper;
     }
-    
+	
     /**
+     * 
      * {@inheritdoc}
      */
-    public function ___getConfigAdvancedInputfields(Field $field) {
-		$wrapper = parent::___getConfigAdvancedInputfields($field);
-        $wrapper->remove($wrapper->get('autojoin'));
-		return $wrapper;
-	}
-
+    public function ___getConfigAdvancedInputfields(Field $field)
+    {
+        $wrapper = parent::___getConfigAdvancedInputfields($field);
+	$wrapper->remove($wrapper->get('autojoin'));
+	return $wrapper;
+    }
+    
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
Don't allow autojoin FieldtypeSeoMaestro because saving data for the field does not work if this is activated